### PR TITLE
Add PlatformEnvs class for environment-specific organization credentials

### DIFF
--- a/nodes/platform_io.py
+++ b/nodes/platform_io.py
@@ -537,3 +537,35 @@ class Output:
                 )
         clean_memory()
         return {"ui": {"signature_output": results}}
+
+
+class PlatformEnvs:
+    @classmethod
+    def INPUT_TYPES(cls):  # type: ignore
+        return {
+            "required": {
+                "environment": (["production", "staging", "develop"],),
+            },
+        }
+
+    RETURN_TYPES = (
+        "STRING",
+        "STRING",
+    )
+    RETURN_NAMES = (
+        "ORG_ID",
+        "ORG_TOKEN",
+    )
+    FUNCTION = "execute"
+    CATEGORY = PLATFORM_IO_CAT
+
+    def execute(self, **kwargs):
+        env = kwargs.get("environment") or ""
+        org_id = "ORG_ID" if env == "production" else f"{env.upper()}_ORG_ID"
+        org_token = "ORG_TOKEN" if env == "production" else f"{env.upper()}_ORG_TOKEN"
+        ORG_ID = os.environ.get(org_id)
+        ORG_TOKEN = os.environ.get(org_token)
+        return (
+            ORG_ID,
+            ORG_TOKEN,
+        )


### PR DESCRIPTION
- Introduced the PlatformEnvs class with a method to define input types for environment selection (production, staging, develop).
- Implemented the execute method to retrieve organization ID and token based on the selected environment.
- Added constants for return types and names to facilitate integration with the platform I/O category.