### PR TITLE
Ml 105 implement row count selector for lora stacker node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -59,7 +59,11 @@ def get_node_class_mappings(nodes_directory: str):
                     snake_case = (
                         str(value.CLASS_ID)
                         if hasattr(value, "CLASS_ID")
-                        else re.sub(r"(?<!^)(?=[A-Z])", "_", class_name).lower()
+                        else (
+                            str(value.CLASS_NAME)
+                            if hasattr(value, "CLASS_NAME")
+                            else re.sub(r"(?<!^)(?=[A-Z])", "_", class_name).lower()
+                        )
                     )
                     key = f"signature_{snake_case}"
                     node_class_mappings[key] = value

--- a/nodes/lora.py
+++ b/nodes/lora.py
@@ -89,6 +89,92 @@ class ApplyLoraStack:
         )
 
 
+class LoraStacker:
+    """Manages multiple LoRA models with configurable weights and modes.
+
+    This node provides an interface for stacking multiple LoRA models with independent
+    weight controls and two operating modes for simple or advanced weight management.
+
+    Args:
+        num_slots (str): Number of LoRA slots to enable (1-10)
+        mode (str): Weight control mode:
+            - "Simple": Single weight per LoRA
+            - "Advanced": Separate model and CLIP weights
+        switch_1..10 (str): "On"/"Off" toggle for each LoRA slot
+        lora_name_1..10 (str): Name of LoRA model for each slot
+        weight_1..10 (float): Weight value for simple mode (-10.0 to 10.0)
+        model_weight_1..10 (float): Model weight for advanced mode (-10.0 to 10.0)
+        clip_weight_1..10 (float): CLIP weight for advanced mode (-10.0 to 10.0)
+        lora_stack (LORA_STACK, optional): Existing stack to extend
+
+    Returns:
+        tuple[LORA_STACK]: Single-element tuple containing list of configured LoRAs
+
+    Notes:
+        - Each slot can be independently enabled/disabled
+        - Simple mode uses same weight for model and CLIP
+        - Advanced mode allows separate model and CLIP weights
+        - Weights can be negative for inverse effects
+        - Can extend existing LORA_STACK
+        - Disabled or empty slots are skipped
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        loras = ["None"] + folder_paths.get_filename_list("loras")
+
+        inputs = {
+            "required": {
+                "num_slots": ([str(i) for i in range(1, 11)], {"default": "1"}),
+                "mode": (["Simple", "Advanced"],),
+            },
+            "optional": {"lora_stack": ("LORA_STACK",)},
+        }
+
+        for i in range(1, 11):
+            inputs["optional"].update(
+                {
+                    f"switch_{i}": (["On", "Off"],),
+                    f"lora_name_{i}": (loras,),
+                    f"weight_{i}": ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01}),
+                    f"model_weight_{i}": ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01}),
+                    f"clip_weight_{i}": ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01}),
+                }
+            )
+
+        return inputs
+
+    RETURN_TYPES = ("LORA_STACK",)
+    RETURN_NAMES = ("lora_stack",)
+    FUNCTION = "execute"
+    CATEGORY = LORA_CAT
+    CLASS_ID = "lora_stacker"
+
+    def execute(self, **kwargs):
+        num_slots = int(kwargs.get("num_slots", 3))
+        mode = kwargs.get("mode", "Simple")
+        lora_stack = kwargs.get("lora_stack")
+
+        lora_list: list = []
+        if lora_stack is not None:
+            lora_list.extend([l for l in lora_stack if l[0] is not None and l[0] != ""])
+
+        for i in range(1, num_slots + 1):
+            switch = kwargs.get(f"switch_{i}")
+            lora_name = kwargs.get(f"lora_name_{i}") or "None"
+
+            if lora_name is not None and lora_name != "None" and switch == "On":
+                if mode == "Simple":
+                    weight = float(kwargs.get(f"weight_{i}") or 1.0)
+                    lora_list.extend([(lora_name, weight, weight)])
+                else:
+                    model_weight = float(kwargs.get(f"model_weight_{i}") or 1.0)
+                    clip_weight = float(kwargs.get(f"clip_weight_{i}") or 1.0)
+                    lora_list.extend([(lora_name, model_weight, clip_weight)])
+
+        return (lora_list,)
+
+
 class LoraStack:
     """Creates a configurable stack of up to 3 LoRA models with adjustable weights.
 
@@ -138,6 +224,8 @@ class LoraStack:
     RETURN_NAMES = ("lora_stack",)
     FUNCTION = "execute"
     CATEGORY = LORA_CAT
+    CLASS_NAME = "LoraStack(OLD)"
+    DEPRECATED = True
 
     def execute(
         self,

--- a/nodes/web/lora.js
+++ b/nodes/web/lora.js
@@ -1,0 +1,248 @@
+import { app } from "../../../scripts/app.js";
+
+function handleNumSlots(node, widget) {
+  const numSlots = parseInt(widget.value);
+
+  if (!node.widgetsHidden) {
+    node.widgetsHidden = [];
+  }
+
+  for (let i = 1; i <= 10; i++) {
+    const widgets = [...node.widgets, ...node.widgetsHidden].filter((w) =>
+      w.name.endsWith(`_${i}`),
+    );
+
+    widgets.forEach((w) => {
+      if (i <= numSlots) {
+        // Show widget - restore from hidden array if it exists
+        const hiddenIndex = node.widgetsHidden.indexOf(w);
+        const widgetIndex = node.widgets.indexOf(w);
+        if (hiddenIndex !== -1 && widgetIndex === -1) {
+          node.widgets.push(w);
+          node.widgetsHidden.splice(hiddenIndex, 1);
+        }
+      } else {
+        // Hide widget - move to hidden array
+        const widgetIndex = node.widgets.indexOf(w);
+        if (widgetIndex !== -1) {
+          node.widgetsHidden.push(w);
+          node.widgets.splice(widgetIndex, 1);
+        }
+      }
+    });
+  }
+
+  // Trigger node size recalculation
+  handleMode(node, undefined);
+}
+
+function handleMode(node, widget) {
+  const modeWidget = node.widgets.find((w) => w.name === "mode");
+  if (!modeWidget) return;
+
+  if (!node.widgetsHiddenModes) {
+    node.widgetsHiddenModes = [];
+  }
+
+  const isSimple = modeWidget.value === "Simple";
+  const allWidgets = [...node.widgets, ...node.widgetsHiddenModes];
+
+  allWidgets.forEach((w) => {
+    const isWeightWidget = w.name.startsWith("weight_");
+    const isAdvancedWidget =
+      w.name.startsWith("model_weight_") || w.name.startsWith("clip_weight_");
+
+    if (isSimple) {
+      if (isWeightWidget) {
+        const slotNum = w.name.replace("weight_", "");
+        const loraNameWidget = node.widgets.findIndex(
+          (widget) => widget.name === `lora_name_${slotNum}`,
+        );
+
+        // Only proceed if corresponding lora_name exists
+        if (loraNameWidget !== -1) {
+          const hiddenIndex = node.widgetsHiddenModes.indexOf(w);
+          const widgetIndex = node.widgets.indexOf(w);
+          if (hiddenIndex !== -1 && widgetIndex === -1) {
+            node.widgets.splice(loraNameWidget + 1, 0, w);
+            node.widgetsHiddenModes.splice(hiddenIndex, 1);
+          }
+        }
+      }
+      if (isAdvancedWidget) {
+        // Hide advanced widgets
+        const widgetIndex = node.widgets.indexOf(w);
+        if (widgetIndex !== -1) {
+          node.widgetsHiddenModes.push(w);
+          node.widgets.splice(widgetIndex, 1);
+        }
+      }
+    } else {
+      if (isWeightWidget) {
+        // Hide simple weight widgets
+        const widgetIndex = node.widgets.indexOf(w);
+        if (widgetIndex !== -1) {
+          node.widgetsHiddenModes.push(w);
+          node.widgets.splice(widgetIndex, 1);
+        }
+      }
+      if (isAdvancedWidget) {
+        const slotNum = w.name.replace("model_weight_", "").replace("clip_weight_", "");
+        const loraNameWidget = node.widgets.findIndex(
+          (widget) => widget.name === `lora_name_${slotNum}`,
+        );
+
+        // Only proceed if corresponding lora_name exists
+        if (loraNameWidget !== -1) {
+          const hiddenIndex = node.widgetsHiddenModes.indexOf(w);
+          const widgetIndex = node.widgets.indexOf(w);
+          if (hiddenIndex !== -1 && widgetIndex === -1) {
+            node.widgets.splice(loraNameWidget + 1, 0, w);
+            node.widgetsHiddenModes.splice(hiddenIndex, 1);
+          }
+        }
+      }
+    }
+  });
+
+  // Trigger node size recalculation
+  node.setSize(node.computeSize());
+}
+
+const nodeWidgetHandlers = {
+  num_slots: handleNumSlots,
+  mode: handleMode,
+};
+
+function widgetLogic(node, widget, isInitial = false) {
+  const handler = nodeWidgetHandlers[widget.name];
+  if (handler && !isInitial) {
+    handler(node, widget);
+  }
+}
+
+const ext = {
+  name: "signature.lora_stacker",
+
+  nodeCreated(node) {
+    const className = node.comfyClass;
+    if (className === "signature_lora_stacker") {
+      // Setup widget value properties first
+      for (const w of node.widgets || []) {
+        let widgetValue = w.value;
+        let originalDescriptor = Object.getOwnPropertyDescriptor(w, "value");
+        Object.defineProperty(w, "value", {
+          get() {
+            let valueToReturn =
+              originalDescriptor && originalDescriptor.get
+                ? originalDescriptor.get.call(w)
+                : widgetValue;
+            return valueToReturn;
+          },
+          set(newVal) {
+            const oldVal = widgetValue;
+
+            if (originalDescriptor && originalDescriptor.set) {
+              originalDescriptor.set.call(w, newVal);
+            } else {
+              widgetValue = newVal;
+            }
+
+            // Only call widgetLogic if the value actually changed
+            if (oldVal !== newVal) {
+              widgetLogic(node, w);
+            }
+          },
+        });
+      }
+
+      // Trigger initial setup after node is created
+      const numSlotsWidget = node.widgets.find((w) => w.name === "num_slots");
+      const modeWidget = node.widgets.find((w) => w.name === "mode");
+
+      if (numSlotsWidget) {
+        handleNumSlots(node, numSlotsWidget);
+      }
+      if (modeWidget) {
+        handleMode(node, modeWidget);
+      }
+    }
+  },
+};
+
+app.registerExtension(ext);
+
+// app.registerExtension({
+//     name: "signature.lora_stacker",
+//     async beforeRegisterNodeDef(nodeType, nodeData, app) {
+//         const class_name = nodeType.comfyClass;
+//         if (class_name === "signature_lora_stacker") {
+//             // Override the onConnectionsChange method to update visibility
+//             nodeType.prototype.onPropertyChanged = function (name, value) {
+//                 const oldValue = this[name];
+//                 if (oldValue === value) return; // Skip if value hasn't changed
+
+//                 this[name] = value; // Update the value
+
+//                 // Handle num_slots changes
+//                 if (name === "num_slots") {
+//                     const numSlots = parseInt(value);
+//                     // Remove or restore inputs based on selected number of slots
+//                     for (let i = 1; i <= 10; i++) {
+//                         const inputs = this.inputs.filter(input =>
+//                             input.name.endsWith(`_${i}`)
+//                         );
+
+//                         if (i > numSlots) {
+//                             // Remove inputs for unused slots
+//                             inputs.forEach(input => {
+//                                 const index = this.inputs.indexOf(input);
+//                                 if (index > -1) {
+//                                     this.inputs.splice(index, 1);
+//                                 }
+//                             });
+//                         } else {
+//                             // Restore inputs if they don't exist
+//                             const hasLora = this.inputs.some(input => input.name === `lora_${i}`);
+//                             if (!hasLora) {
+//                                 this.inputs.push(
+//                                     { name: `lora_${i}`, type: '*', link_type: LiteGraph.INPUT },
+//                                     { name: `weight_${i}`, type: 'number', default: 1.0 },
+//                                     { name: `model_weight_${i}`, type: 'number', default: 1.0 },
+//                                     { name: `clip_weight_${i}`, type: 'number', default: 1.0 }
+//                                 );
+//                             }
+//                         }
+//                     }
+//                 }
+//                 // Handle mode changes
+//                 else if (name.startsWith("mode_")) {
+//                     const slotNum = name.split("_")[1];
+//                     const isSimple = value === "Simple";
+
+//                     // Remove or add weight inputs based on mode
+//                     if (isSimple) {
+//                         // Remove model and clip weights, add simple weight if not exists
+//                         this.inputs = this.inputs.filter(input =>
+//                             !input.name.match(`(model_weight_${slotNum}|clip_weight_${slotNum})`)
+//                         );
+//                         if (!this.inputs.some(input => input.name === `weight_${slotNum}`)) {
+//                             this.inputs.push({ name: `weight_${slotNum}`, type: 'number', default: 1.0 });
+//                         }
+//                     } else {
+//                         // Remove simple weight, add model and clip weights if not exist
+//                         this.inputs = this.inputs.filter(input =>
+//                             input.name !== `weight_${slotNum}`
+//                         );
+//                         if (!this.inputs.some(input => input.name === `model_weight_${slotNum}`)) {
+//                             this.inputs.push(
+//                                 { name: `model_weight_${slotNum}`, type: 'number', default: 1.0 },
+//                                 { name: `clip_weight_${slotNum}`, type: 'number', default: 1.0 }
+//                             );
+//                         }
+//                     }
+//                 }
+//             };
+//         }
+//     }
+// });

--- a/nodes/web/lora.js
+++ b/nodes/web/lora.js
@@ -14,7 +14,6 @@ function handleNumSlots(node, widget) {
 
     widgets.forEach((w) => {
       if (i <= numSlots) {
-        // Show widget - restore from hidden array if it exists
         const hiddenIndex = node.widgetsHidden.indexOf(w);
         const widgetIndex = node.widgets.indexOf(w);
         if (hiddenIndex !== -1 && widgetIndex === -1) {
@@ -22,7 +21,6 @@ function handleNumSlots(node, widget) {
           node.widgetsHidden.splice(hiddenIndex, 1);
         }
       } else {
-        // Hide widget - move to hidden array
         const widgetIndex = node.widgets.indexOf(w);
         if (widgetIndex !== -1) {
           node.widgetsHidden.push(w);
@@ -32,7 +30,6 @@ function handleNumSlots(node, widget) {
     });
   }
 
-  // Trigger node size recalculation
   handleMode(node, undefined);
 }
 
@@ -59,7 +56,6 @@ function handleMode(node, widget) {
           (widget) => widget.name === `lora_name_${slotNum}`,
         );
 
-        // Only proceed if corresponding lora_name exists
         if (loraNameWidget !== -1) {
           const hiddenIndex = node.widgetsHiddenModes.indexOf(w);
           const widgetIndex = node.widgets.indexOf(w);
@@ -70,7 +66,6 @@ function handleMode(node, widget) {
         }
       }
       if (isAdvancedWidget) {
-        // Hide advanced widgets
         const widgetIndex = node.widgets.indexOf(w);
         if (widgetIndex !== -1) {
           node.widgetsHiddenModes.push(w);
@@ -79,7 +74,6 @@ function handleMode(node, widget) {
       }
     } else {
       if (isWeightWidget) {
-        // Hide simple weight widgets
         const widgetIndex = node.widgets.indexOf(w);
         if (widgetIndex !== -1) {
           node.widgetsHiddenModes.push(w);
@@ -92,7 +86,6 @@ function handleMode(node, widget) {
           (widget) => widget.name === `lora_name_${slotNum}`,
         );
 
-        // Only proceed if corresponding lora_name exists
         if (loraNameWidget !== -1) {
           const hiddenIndex = node.widgetsHiddenModes.indexOf(w);
           const widgetIndex = node.widgets.indexOf(w);
@@ -105,7 +98,6 @@ function handleMode(node, widget) {
     }
   });
 
-  // Trigger node size recalculation
   node.setSize(node.computeSize());
 }
 
@@ -127,7 +119,6 @@ const ext = {
   nodeCreated(node) {
     const className = node.comfyClass;
     if (className === "signature_lora_stacker") {
-      // Setup widget value properties first
       for (const w of node.widgets || []) {
         let widgetValue = w.value;
         let originalDescriptor = Object.getOwnPropertyDescriptor(w, "value");
@@ -148,7 +139,6 @@ const ext = {
               widgetValue = newVal;
             }
 
-            // Only call widgetLogic if the value actually changed
             if (oldVal !== newVal) {
               widgetLogic(node, w);
             }
@@ -156,7 +146,6 @@ const ext = {
         });
       }
 
-      // Trigger initial setup after node is created
       const numSlotsWidget = node.widgets.find((w) => w.name === "num_slots");
       const modeWidget = node.widgets.find((w) => w.name === "mode");
 
@@ -171,78 +160,3 @@ const ext = {
 };
 
 app.registerExtension(ext);
-
-// app.registerExtension({
-//     name: "signature.lora_stacker",
-//     async beforeRegisterNodeDef(nodeType, nodeData, app) {
-//         const class_name = nodeType.comfyClass;
-//         if (class_name === "signature_lora_stacker") {
-//             // Override the onConnectionsChange method to update visibility
-//             nodeType.prototype.onPropertyChanged = function (name, value) {
-//                 const oldValue = this[name];
-//                 if (oldValue === value) return; // Skip if value hasn't changed
-
-//                 this[name] = value; // Update the value
-
-//                 // Handle num_slots changes
-//                 if (name === "num_slots") {
-//                     const numSlots = parseInt(value);
-//                     // Remove or restore inputs based on selected number of slots
-//                     for (let i = 1; i <= 10; i++) {
-//                         const inputs = this.inputs.filter(input =>
-//                             input.name.endsWith(`_${i}`)
-//                         );
-
-//                         if (i > numSlots) {
-//                             // Remove inputs for unused slots
-//                             inputs.forEach(input => {
-//                                 const index = this.inputs.indexOf(input);
-//                                 if (index > -1) {
-//                                     this.inputs.splice(index, 1);
-//                                 }
-//                             });
-//                         } else {
-//                             // Restore inputs if they don't exist
-//                             const hasLora = this.inputs.some(input => input.name === `lora_${i}`);
-//                             if (!hasLora) {
-//                                 this.inputs.push(
-//                                     { name: `lora_${i}`, type: '*', link_type: LiteGraph.INPUT },
-//                                     { name: `weight_${i}`, type: 'number', default: 1.0 },
-//                                     { name: `model_weight_${i}`, type: 'number', default: 1.0 },
-//                                     { name: `clip_weight_${i}`, type: 'number', default: 1.0 }
-//                                 );
-//                             }
-//                         }
-//                     }
-//                 }
-//                 // Handle mode changes
-//                 else if (name.startsWith("mode_")) {
-//                     const slotNum = name.split("_")[1];
-//                     const isSimple = value === "Simple";
-
-//                     // Remove or add weight inputs based on mode
-//                     if (isSimple) {
-//                         // Remove model and clip weights, add simple weight if not exists
-//                         this.inputs = this.inputs.filter(input =>
-//                             !input.name.match(`(model_weight_${slotNum}|clip_weight_${slotNum})`)
-//                         );
-//                         if (!this.inputs.some(input => input.name === `weight_${slotNum}`)) {
-//                             this.inputs.push({ name: `weight_${slotNum}`, type: 'number', default: 1.0 });
-//                         }
-//                     } else {
-//                         // Remove simple weight, add model and clip weights if not exist
-//                         this.inputs = this.inputs.filter(input =>
-//                             input.name !== `weight_${slotNum}`
-//                         );
-//                         if (!this.inputs.some(input => input.name === `model_weight_${slotNum}`)) {
-//                             this.inputs.push(
-//                                 { name: `model_weight_${slotNum}`, type: 'number', default: 1.0 },
-//                                 { name: `clip_weight_${slotNum}`, type: 'number', default: 1.0 }
-//                             );
-//                         }
-//                     }
-//                 }
-//             };
-//         }
-//     }
-// });


### PR DESCRIPTION
feat(nodes): Add new LoraStacker node with enhanced functionality

- Introduce new LoraStacker node supporting up to 10 LoRA slots
- Add Simple/Advanced weight control modes
- Implement per-slot enable/disable switches
- Mark old LoraStack node as deprecated
- Update node class mapping to support CLASS_NAME fallback

The new LoraStacker provides more flexibility and control over LoRA combinations,
replacing the limited 3-slot LoraStack implementation.
![Screenshot 2024-11-13 at 17 30 07](https://github.com/user-attachments/assets/bf114b17-196b-41ea-ae04-2fda7faa57da)
